### PR TITLE
fix(user): add getting budgie page

### DIFF
--- a/docs/user/getting-budgie.mdx
+++ b/docs/user/getting-budgie.mdx
@@ -1,0 +1,15 @@
+---
+title: Getting Budgie
+description: Find current Budgie Desktop installation options.
+sidebar_label: Getting Budgie
+---
+
+# Getting Budgie
+
+Budgie Desktop is packaged by multiple Linux distributions. The canonical list of
+current installation options is maintained on the [Buddies of Budgie website].
+
+Use that page to find distribution images, package availability, and installation
+guidance for your system.
+
+[Buddies of Budgie website]: https://buddiesofbudgie.org/get-budgie

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -103,10 +103,6 @@ const config = {
             from: '/10.9.x/user/getting-budgie',
             to: 'https://buddiesofbudgie.org/get-budgie',
           },
-          {
-            from: '/user/getting-budgie',
-            to: 'https://buddiesofbudgie.org/get-budgie',
-          },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- Add a current-version `/user/getting-budgie` docs page that points users to the canonical Get Budgie page
- Remove the current redirect entry so the reported docs URL resolves to content directly
- Keep the existing versioned redirects for older docs paths

Closes #35

## Verification
- yarn install --immutable
- yarn biome check docusaurus.config.js
- git diff --check
- yarn clear && yarn build
- test -s build/user/getting-budgie/index.html && rg -n "Getting Budgie|buddiesofbudgie.org/get-budgie" build/user/getting-budgie/index.html

## Known existing issue
- yarn typecheck still fails on existing TypeScript errors outside this change, including missing `src/data/schedules/unified` and JSX component return-type errors in existing files.

## AI disclosure
This contribution was prepared with AI assistance and manually reviewed before submission.